### PR TITLE
add get_default_instance

### DIFF
--- a/SDIOBlockDevice.cpp
+++ b/SDIOBlockDevice.cpp
@@ -74,6 +74,12 @@ SDIOBlockDevice::~SDIOBlockDevice()
     }
 }
 
+BlockDevice * BlockDevice::get_default_instance()
+{
+    static SDIOBlockDevice bd;
+    return &bd;
+}
+
 int SDIOBlockDevice::init()
 {
     debug_if(SD_DBG, "init Card...\r\n");

--- a/SDIOBlockDevice.h
+++ b/SDIOBlockDevice.h
@@ -26,7 +26,14 @@ class SDIOBlockDevice : public mbed::BlockDevice {
 public:
     SDIOBlockDevice(PinName cardDetect = NC);
     virtual ~SDIOBlockDevice();
-    /** Initialize a block device
+  
+    /** Pass pointer to block device object 
+     * 
+     *  @return         Pointer to Blockdevice 
+     */
+    static BlockDevice *get_default_instance();
+	
+  /** Initialize a block device
      *
      *  @return         0 on success or a negative error code on failure
      */


### PR DESCRIPTION
Override the default "weak" implementation of the "get_default_instance" in the blockdevice class.  Pass a pointer to the SDIO blockdevice instance.  This allows applications to get the default block device without knowledge of the underlying type of storage.

Application example code:
```
BlockDevice *bd = BlockDevice::get_default_instance();
```
documentation of this feature:
https://os.mbed.com/docs/mbed-os/v5.13/apis/blockdevice.html

